### PR TITLE
GitHub Action to test build the docker image

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,9 @@
+name: Test build docker image
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build docker image
+        run: docker build .

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,4 @@
-name: Test build docker image
+name: Test build Docker image
 on: [push, pull_request, workflow_dispatch]
 jobs:
   test-build:


### PR DESCRIPTION
The workflow can be fired off manually, but triggers with pushes and pull requests.
It doesn't send the data anywhere afterwards, it just tests if the image can be built.

Later on, some kind of test run could be used, though for the moment, simply `docker run`-ning it wouldn't work as it would stay stuck with rpaste running.