### PR TITLE
Publish master branch images on GitHub's Container Repository as Packages

### DIFF
--- a/.github/workflows/release-dev-image.yml
+++ b/.github/workflows/release-dev-image.yml
@@ -1,0 +1,25 @@
+name: Release dev image
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:dev

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,10 @@
 name: Test build Docker image
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - master
 jobs:
   test-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
On master branch pushes, the workflow will build and publish images for amd64 as GitHub packages.
These images can then be downloaded with `docker image pull ghcr.io/winny-/rpaste:dev`.

A modification has also been done on the previous `test-build.yml` workflow to not trigger it on master branch pushes, as the new workflow handles that.